### PR TITLE
Update nvme-provisioner dockerfile to pull base image from ECR

### DIFF
--- a/tools/nvme-provisioner/Dockerfile
+++ b/tools/nvme-provisioner/Dockerfile
@@ -1,5 +1,5 @@
 # Fix for issue 72
-FROM debian:bookworm-slim
+FROM public.ecr.aws/debian/debian:bookworm-slim
 
 RUN  apt-get update && apt-get -y install nvme-cli mdadm && apt-get -y clean && apt-get -y autoremove
 COPY nvme-provisioner.sh /usr/local/bin/


### PR DESCRIPTION
As I ran through many deployments of this solution, the CodeBuild deployment would randomly fail due to docker hub throttling. While the vast majority of the solution references the public ECR repository, this one image was referencing docker hub for the debian:bookworm-slim image. 

Updating this to the ECR repository for the same image resolved the issue and resulted in consistently reliable deployment.