### PR TITLE
Remove us-east-1a and us-east-1b from benchmark nodepool requirements

### DIFF
--- a/deployment/infrastructure/publisher-eks/nodepool.yaml
+++ b/deployment/infrastructure/publisher-eks/nodepool.yaml
@@ -20,9 +20,6 @@ spec:
         - key: "eks.amazonaws.com/instance-cpu"
           operator: In
           values: ["4", "8", "16"]
-        - key: "topology.kubernetes.io/zone"
-          operator: In
-          values: ["us-east-1a", "us-east-1b"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["arm64"]


### PR DESCRIPTION
During testing I found that the load-generator pod would fail to schedule on some deployments. Further investigation found that this was due to the benchmark nodepool having a requirement of us-east-1a and us-east-1b, but the EKS cluster had no such restriction and with auto mode was deploying in other AZ's. Removing this requirement from the nodepool allows the pod to reliably schedule on every deployment.