### PR TITLE
Set consolidationPolicy to "WhenEmpty" to prevent unexpected termination of load tests

### DIFF
--- a/deployment/infrastructure/publisher-eks/nodepool.yaml
+++ b/deployment/infrastructure/publisher-eks/nodepool.yaml
@@ -33,3 +33,4 @@ spec:
   
   disruption:
     consolidationPolicy: WhenEmpty
+    consolidateAfter: 0s

--- a/deployment/infrastructure/publisher-eks/nodepool.yaml
+++ b/deployment/infrastructure/publisher-eks/nodepool.yaml
@@ -30,3 +30,6 @@ spec:
   limits:
     cpu: "1000"
     memory: 1000Gi
+  
+  disruption:
+    consolidationPolicy: WhenEmpty


### PR DESCRIPTION
During testing I've noticed that karpenter is rather aggressive about what it considers "underutilized". This has led to a couple of instances where load tests have been interrupted due to the instance being shut down mid-test. Setting the consolidation policy to "WhenEmpty" will ensure that nodes are only consolidated if they're empty and not running any pods. 